### PR TITLE
Update target framework and package versions and add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Ignore all files and directories
+**
+
+# But do not ignore Dockerfile and .dockerignore
+!Dockerfile
+!.dockerignore
+
+# Do not ignore project and solution files
+!*.csproj
+!*.sln
+
+# Include source code directories
+!Authlete/**
+!Authlete.Tests/**
+
+# Exclude bin and obj folders to prevent including build output in the Docker context
+**/[Bb]in/
+**/[Oo]bj/
+
+# Exclude other unnecessary files and directories
+**/*.user
+**/*.vs/
+**/*.vscode/
+**/*.[Dd]S_Store
+**/.azure/
+**/.github/
+**/.git/
+**/README.md
+**/LICENSE
+
+# Ignore specific app settings or environment files that should not be included
+# appsettings.Production.json
+# .env

--- a/Authlete.Tests/Authlete.Tests.csproj
+++ b/Authlete.Tests/Authlete.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Authlete.Tests/Authlete.Tests.csproj
+++ b/Authlete.Tests/Authlete.Tests.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Authlete/Authlete.csproj
+++ b/Authlete/Authlete.csproj
@@ -5,7 +5,7 @@
     <ReleaseVersion>1.0.0</ReleaseVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <PackageId>Authlete.Authlete</PackageId>
-    <PackageVersion>1.5.0</PackageVersion>
+    <PackageVersion>1.6.0</PackageVersion>
     <Authors>Authlete</Authors>
     <PackageLicenseUrl>https://github.com/authlete/authlete-csharp/LICENSE</PackageLicenseUrl>
     <Owners>authlete</Owners>

--- a/Authlete/Authlete.csproj
+++ b/Authlete/Authlete.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ReleaseVersion>1.0.0</ReleaseVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <PackageId>Authlete.Authlete</PackageId>
@@ -31,7 +31,7 @@
     <Folder Include="Handler\Spi\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2" />
   </ItemGroup>
 </Project>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 CHANGES
 =======
 
+1.6.0 (2024-03-05)
+------------------
+
+- Update dotnet framework to 8.0.
+- Add Docker support for building and testing.
+
+
 1.5.0 (2020-11-06)
 ------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the .NET 8.0 SDK image to build the application
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 WORKDIR /src
 
 # Copy the solution file
@@ -19,9 +19,5 @@ COPY . .
 # Build the project
 RUN dotnet build "Authlete/Authlete.csproj" -c Release -o /app/build
 
-# Run tests and generate TRX test results
-RUN dotnet test "Authlete.Tests/Authlete.Tests.csproj" -c Release --no-restore --logger "trx;LogFileName=test_results.trx"
-
-# Copy test results to a known location
-RUN mkdir /test-results
-RUN cp Authlete.Tests/TestResults/*.trx /test-results
+# Run tests and generate detailed test results in the console
+RUN dotnet test "Authlete.Tests/Authlete.Tests.csproj" -c Release --no-restore --logger "console;verbosity=detailed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,3 @@ RUN dotnet test "Authlete.Tests/Authlete.Tests.csproj" -c Release --no-restore -
 # Copy test results to a known location
 RUN mkdir /test-results
 RUN cp Authlete.Tests/TestResults/*.trx /test-results
-
-# Publish the application
-FROM build AS publish
-RUN dotnet publish "Authlete/Authlete.csproj" -c Release -o /app/publish
-
-# Final stage/image uses the .NET runtime
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
-WORKDIR /app
-COPY --from=publish /app/publish ./
-
-CMD ["dotnet", "Authlete.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Use the .NET 8.0 SDK image to build the application
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy the solution file
+# Using a wildcard to copy the solution file, suitable if there's only one .sln file in the root
+COPY *.sln .
+
+# Copy the csproj files and restore as distinct layers
+COPY Authlete/Authlete.csproj Authlete/
+COPY Authlete.Tests/Authlete.Tests.csproj Authlete.Tests/
+
+# Restore NuGet packages
+RUN dotnet restore "Authlete.sln" -v d
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the project
+RUN dotnet build "Authlete/Authlete.csproj" -c Release -o /app/build
+
+# Run tests and generate TRX test results
+RUN dotnet test "Authlete.Tests/Authlete.Tests.csproj" -c Release --no-restore --logger "trx;LogFileName=test_results.trx"
+
+# Copy test results to a known location
+RUN mkdir /test-results
+RUN cp Authlete.Tests/TestResults/*.trx /test-results
+
+# Publish the application
+FROM build AS publish
+RUN dotnet publish "Authlete/Authlete.csproj" -c Release -o /app/publish
+
+# Final stage/image uses the .NET runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=publish /app/publish ./
+
+CMD ["dotnet", "Authlete.dll"]

--- a/README.md
+++ b/README.md
@@ -355,14 +355,13 @@ This project supports building and running inside a Docker container. The instru
 To build the Docker image with detailed build output, use the following command:
 
 ```bash
-docker build -t authlete-test --progress=plain --no-cache --target build .
+docker build -t authlete-test --progress=plain --no-cache .
 ```
 
 This command performs the following actions:
 - `-t authlete-test` tags the built Docker image as `authlete-test`.
 - `--progress=plain` displays the build output in plain text, providing detailed information during the build process.
 - `--no-cache` ensures that Docker does not use any cached layers from previous builds, forcing all steps to be re-executed.
-- `--target build` specifies that the Docker build process should stop after completing the `build` stage. This is particularly useful if you want to run tests without deploying the final application as part of the build process.
 
 #### Retrieving Test Results
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,54 @@ How To Test
     $ cd Authlete.Tests
     $ dotnet test
 
+Docker Support
+-----------
+#### Building the Docker Image with Detailed Output
+
+This project supports building and running inside a Docker container. The instructions below guide you through the process of building the Docker image, running the container, and retrieving test results with detailed build output.
+
+#### Building the Docker Image
+
+To build the Docker image with detailed build output, use the following command:
+
+```bash
+docker build -t authlete-test --progress=plain --no-cache --target build .
+```
+
+This command performs the following actions:
+- `-t authlete-test` tags the built Docker image as `authlete-test`.
+- `--progress=plain` displays the build output in plain text, providing detailed information during the build process.
+- `--no-cache` ensures that Docker does not use any cached layers from previous builds, forcing all steps to be re-executed.
+- `--target build` specifies that the Docker build process should stop after completing the `build` stage. This is particularly useful if you want to run tests without deploying the final application as part of the build process.
+
+#### Retrieving Test Results
+
+The Dockerfile is configured to generate test results in TRX format during the build process. To extract these test results from the Docker image to your host system, follow these steps:
+
+1. **Create a Temporary Container from the Image**:
+   Create a container named `temp-container` from your `authlete-test` image without starting it:
+
+   ```bash
+   docker create --name temp-container authlete-test
+   ```
+
+2. **Copy Test Results to Host**:
+   Copy the test results from the `temp-container` to a directory on your host machine:
+
+   ```bash
+   docker cp temp-container:/test-results ./test-results
+   ```
+
+   This copies the test results stored at `/test-results` inside the container to a `./test-results` directory on your host.
+
+3. **Cleanup**:
+   Remove the temporary container:
+
+   ```bash
+   docker rm temp-container
+   ```
+
+Now, you'll find the `.trx` test result files in the `./test-results` directory on your host machine, ready for review.
 
 How To Release
 --------------

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.201",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
The target framework in the `Authlete` and `Authlete.Tests` projects has been updated from `netstandard1.4` and `netcoreapp2.0` respectively to `net8.0`. 
Additionally, the versions of several packages have been upgraded for improved compatibility and latest features. 
A `global.json` file has also been added to specify `sdk version` and `options`.